### PR TITLE
Fix local macos build

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,26 @@ package snappy-c
     /path/to/snappy/lib
 ```
 
+To build the benchmarks, you must add the same configuration for the `snappy` package:
+
+```cabal
+package snappy
+  extra-include-dirs:
+    /path/to/snappy/include
+  extra-lib-dirs:
+    /path/to/snappy/lib
+```
+
 In my case, on a mac using homebrew, the following suffices:
 
 ```cabal
 package snappy-c
+  extra-lib-dirs:
+    /opt/homebrew/lib
+  extra-include-dirs:
+    /opt/homebrew/include
+
+package snappy
   extra-lib-dirs:
     /opt/homebrew/lib
   extra-include-dirs:

--- a/cabal.project
+++ b/cabal.project
@@ -6,5 +6,5 @@ package snappy-c
 
 source-repository-package
   type: git
-  location: https://github.com/edsko/snappy.git
-  tag: 4f6288ea7fff56967a37ddccbd4894fad0a1b6b9
+  location: https://github.com/FinleyMcIlwaine/snappy.git
+  tag: aef1570eed2e403d991573714c388c34fc1879ed


### PR DESCRIPTION
We need the `extra-{lib,include}-dirs` for `snappy` as well. Also needed to bump the reference to `snappy` to a commit that properly includes `cxx-options: -std=c++11`.

`cabal build all` succeeds for me locally on macos sequoia now. Resolves #4 